### PR TITLE
Resolves compilation issues on MacOS and adds dependencies on README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+bin/
+
+compile_commands.json
+*.o

--- a/README.md
+++ b/README.md
@@ -19,9 +19,16 @@ A "fancy" snake game written in C using [SDL2](https://www.libsdl.org/), where t
 one eye (for some reason) and you eat cheese instead of apples.
 
 ## Table of contents
+* [Prerequisites](#prerequisites)
 * [Quickstart](#quickstart)
 * [Bugs](#bugs)
 * [Make](#make)
+
+## Prerequisites
+Cnake requires the following dependencies to be installed globally:
+* [SDL2/SDL_image](https://github.com/libsdl-org/SDL_image)
+* [SDL2/SDL_ttf](https://github.com/libsdl-org/SDL_ttf)
+* [SDL2/SDL_mixer](https://github.com/libsdl-org/SDL_mixer)
 
 ## Quickstart
 ```sh

--- a/src/game.c
+++ b/src/game.c
@@ -43,16 +43,22 @@ static char *get_exec_folder_path(void) {
 	else
 		strcpy(buf, argv[0]);
 #elif defined(PLATFORM_APPLE)
-	uint32_t size = PATH_MAX;
-	if (_NSGetExecutablePath(buffer, &size) != 0)
+	uint32_t len = PATH_MAX;
+	if (_NSGetExecutablePath(buf, &len) != 0)
 		strcpy(buf, argv[0]);
 #elif defined(PLATFORM_WINDOWS)
 	GetModuleFileName(NULL, buf, PATH_MAX);
-#elif defined(PLATFORM_UNIX) || defined(PLATFORM_UNKNOWN)
-	strcpy(buf, argv[0]);
+#else
+    strcpy(buf, argv[0]);
 #endif
-
-	for (size_t i = len - 1; i > 0; -- i) {
+#if defined(PLATFORM_LINUX)
+    ssize_t i = len - 1;
+#elif defined(PLATFORM_APPLE)
+    uint32_t i = len - 1;
+#elif defined(PLATFORM_WINDOWS)
+    size_t i = len - 1;
+#endif
+    for (; i > 0; -- i) {
 		if (buf[i] == '/' || buf[i] == '\\') {
 			buf[i] = '\0';
 			break;

--- a/src/snake.h
+++ b/src/snake.h
@@ -31,7 +31,7 @@ struct snake_textures {
 #define SNAKE_TONGUE_MIN_DELAY 300
 #define SNAKE_TONGUE_MAX_DELAY 600
 
-static_assert(SNAKE_TONGUE_MAX_DELAY > SNAKE_TONGUE_MIN_DELAY);
+static_assert(SNAKE_TONGUE_MAX_DELAY > SNAKE_TONGUE_MIN_DELAY, "");
 
 enum tongue_state {
 	TONGUE_HIDDEN = 0,


### PR DESCRIPTION
This PR serves to fix two issues:

- First, dependancies required by Cnake not being available by default or being listed on the README so users can download it for themselves
- Secondly, to resolve an issue  (#1) when compiling Cnake on MacOS with all dependencies installed.

